### PR TITLE
fix(github-pages): update build command and add 404.html for SPA rout…

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,10 +29,10 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build -- --configuration production --output-path=dist/notes-app  --base-href="/notes-app/"
+        run: npm run build -- --configuration production --base-href="/notes-app/"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/notes-app
+          publish_dir: ./dist/notes-app/browser

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:notes-app": "node dist/notes-app/server/server.mjs",
-    "format": "prettier --write \"src/**/*.{ts,js,html,css}\""
+    "format": "prettier --write \"src/**/*.{ts,js,html,css}\"",
+    "deploy:gh-pages": "ng build --configuration production --base-href=/notes-app/"
   },
   "private": true,
   "dependencies": {

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Notes App</title>
+    <script type="text/javascript">
+      // Single-page application routing hack for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          '//' +
+          l.hostname +
+          (l.port ? ':' + l.port : '') +
+          l.pathname
+            .split('/')
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join('/') +
+          '/?/' +
+          l.pathname
+            .slice(1)
+            .split('/')
+            .slice(pathSegmentsToKeep)
+            .join('/')
+            .replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash,
+      );
+    </script>
+  </head>
+  <body>
+    Redirecting...
+  </body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,34 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>NotesApp</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+    <head>
+        <meta charset="utf-8" />
+        <title>NotesApp</title>
+        <base href="/" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" type="image/x-icon" href="favicon.ico" />
+        <!-- GitHub Pages SPA routing support -->
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // https://github.com/rafgraph/spa-github-pages
+            (function (l) {
+                if (l.search[1] === "/") {
+                    var decoded = l.search
+                        .slice(1)
+                        .split("&")
+                        .map(function (s) {
+                            return s.replace(/~and~/g, "&");
+                        })
+                        .join("?");
+                    window.history.replaceState(
+                        null,
+                        null,
+                        l.pathname.slice(0, -1) + decoded + l.hash
+                    );
+                }
+            })(window.location);
+        </script>
+    </head>
+    <body>
+        <app-root></app-root>
+    </body>
 </html>


### PR DESCRIPTION
This pull request introduces changes to improve the deployment of the Notes App to GitHub Pages, including adjustments to the build process, SPA (Single Page Application) routing support, and new scripts for deployment. Below are the most important changes grouped by theme.

### Deployment Process Updates
* Updated the `gh-pages` workflow in `.github/workflows/gh-pages.yml` to modify the `npm run build` command by removing the `--output-path` option and changing the `publish_dir` to `./dist/notes-app/browser` for compatibility with the Angular Universal build structure.
* Added a new `deploy:gh-pages` script in `package.json` to simplify deployment by running the production build with the correct base href for GitHub Pages (`/notes-app/`).

### SPA Routing Support for GitHub Pages
* Added a custom `404.html` file in the `public` folder with a JavaScript-based redirect to ensure proper SPA routing on GitHub Pages. This addresses the issue of page reloads breaking due to missing routes.
* Updated `src/index.html` to include a script for handling SPA routing on GitHub Pages. This ensures that URLs with query parameters and hashes are correctly interpreted.…ing support